### PR TITLE
Custom Tag version

### DIFF
--- a/mustache/mustache.cfm
+++ b/mustache/mustache.cfm
@@ -1,0 +1,15 @@
+<cfsetting enablecfoutputonly="true"/>
+
+<cfparam name="attributes.mustache" type="any" default="#createObject("component","Mustache").init()#" />
+<cfparam name="attributes.context" type="any" />
+<cfparam name="attributes.partials" type="struct" default="#structNew()#" />
+
+<cfif not thisTag.hasEndTag>
+	<cfthrow type="MissingEndTag" message="mustache requires an end tag" />
+</cfif>
+
+<cfif thisTag.executionMode eq "end">
+	<cfset thisTag.generatedContent = trim(attributes.mustache.render(template = thisTag.generatedContent, context = attributes.context, partials = attributes.partials)) />
+</cfif>
+
+<cfsetting enablecfoutputonly="false"/>

--- a/readme.markdown
+++ b/readme.markdown
@@ -46,3 +46,23 @@ Result:
     Hello Patrick
     You have just won $1000!
     Well, $600, after taxes.
+
+A custom tag is also included so you can render templates like so:
+
+<cfset context = {
+	name = "Patrick",
+	value = 1000,
+	in_ca = true,
+	taxed_value = 600
+} />
+
+<cfimport taglib="/path/to/mustache/dir" prefix="stache" />
+<stache:mustache context="#context#">
+<cfoutput>
+Hello {{name}}
+You have just won ${{value}}!
+{{##in_ca}}
+Well, ${{taxed_value}}, after taxes.
+{{/in_ca}}
+</cfoutput>
+</stache:mustache>

--- a/tests/CustomTagTest.cfc
+++ b/tests/CustomTagTest.cfc
@@ -1,0 +1,274 @@
+<cfcomponent extends="mxunit.framework.TestCase">
+
+	<cfimport taglib="../mustache" prefix="stache" />
+
+	<cffunction name="setup">
+		<cfset partials = {}/>
+		<cfset stache = createObject("component", "mustache.Mustache").init()/>
+	</cffunction>
+
+	<cffunction name="tearDown">
+		<cfset var result = "" />
+		<cfsavecontent variable="result">
+			<stache:mustache context="#context#" partials="#partials#" mustache="#stache#">
+				<cfoutput>#template#</cfoutput>
+			</stache:mustache>
+		</cfsavecontent>
+		<cfset assertEquals(expected, trim(result))/>
+	</cffunction>
+
+  <cffunction name="basic">
+    <cfset context = { thing = 'world'} />
+    <cfset template = "Hello, {{thing}}!" />
+    <cfset expected = "Hello, World!" />
+  </cffunction>
+
+  <cffunction name="lessBasic">
+    <cfset context = { beverage = 'soda', person = 'Bob' } />
+    <cfset template = "It's a nice day for {{beverage}}, right {{person}}?" />
+    <cfset expected = "It's a nice day for soda, right Bob?"/>
+  </cffunction>
+
+  <cffunction name="evenLessBasic">
+    <cfset context = { name = 'Jon', thing = 'racecar'} />
+    <cfset template = "I think {{name}} wants a {{thing}}, right {{name}}?">
+    <cfset expected = "I think Jon wants a racecar, right Jon?" />
+  </cffunction>
+
+  <cffunction name="ignoresMisses">
+    <cfset context = { name = 'Jon'} />
+    <cfset template = "I think {{name}} wants a {{thing}}, right {{name}}?">
+    <cfset expected = "I think Jon wants a , right Jon?" />
+  </cffunction>
+
+  <cffunction name="renderZero">
+    <cfset context = { value = 0 } />
+    <cfset template = "My value is {{value}}." />
+    <cfset expected = "My value is 0." />
+  </cffunction>
+
+  <cffunction name="comments">
+    <cfset context = structNew() />
+    <cfset context['!'] = "FAIL" />
+    <cfset context['the'] = "FAIL" />
+    <cfset template = "What {{!the}} what?" />
+    <cfset expected = "What  what?" />
+  </cffunction>
+
+  <cffunction name="falseSectionsAreHidden">
+    <cfset context =  { set = false } />
+    <cfset template = "Ready {{##set}}set {{/set}}go!" />
+    <cfset expected = "Ready go!" />
+  </cffunction>
+
+   <cffunction name="trueSectionsAreShown">
+    <cfset context =  { set = true }  />
+    <cfset template = "Ready {{##set}}set {{/set}}go!" />
+    <cfset expected = "Ready set go!" />
+  </cffunction>
+
+  <cffunction name="falseSectionsAreShownIfInverted">
+    <cfset context =  { set = false }  />
+    <cfset template = "Ready {{^set}}set {{/set}}go!" />
+    <cfset expected = "Ready set go!" />
+  </cffunction>
+
+  <cffunction name="trueSectionsAreHiddenIfInverted">
+    <cfset context =  { set = true }  />
+    <cfset template = "Ready {{^set}}set {{/set}}go!" />
+    <cfset expected = "Ready go!" />
+  </cffunction>
+
+  <cffunction name="emptyStringsAreFalse">
+    <cfset context =  { set = "" }  />
+    <cfset template = "Ready {{##set}}set {{/set}}go!" />
+    <cfset expected = "Ready go!" />
+  </cffunction>
+
+  <cffunction name="emptyQueriesAreFase">
+    <cfset context =  { set = QueryNew('firstname,lastname') }  />
+    <cfset template = "Ready {{^set}}No records found {{/set}}go!" />
+     <cfset expected = "Ready No records found go!" />
+  </cffunction>
+
+  <cffunction name="emptyStructsAreFalse">
+    <cfset context =  { set = {} } />
+     <cfset template = "Ready {{^set}}No records found {{/set}}go!" />
+     <cfset expected = "Ready No records found go!" />
+  </cffunction>
+
+  <cffunction name="emptyArraysAreFalse">
+    <cfset context =  { set = [] }  />
+     <cfset template = "Ready {{^set}}No records found {{/set}}go!" />
+     <cfset expected = "Ready No records found go!" />
+  </cffunction>
+
+	<cffunction name="nonEmptyStringsAreTrue">
+    <cfset context =  { set = "x" }  />
+    <cfset template = "Ready {{##set}}set {{/set}}go!" />
+    <cfset expected = "Ready set go!" />
+  </cffunction>
+
+	<cffunction name="skipMissingField">
+		<cfset context =  structNew()  />
+    <cfset template = "There's something {{##foo}}missing{{/foo}}!" />
+    <cfset expected = "There's something !" />
+	</cffunction>
+
+  <cffunction name="structAsSection">
+    <cfset context = {
+      contact = { name = 'Jenny', phone = '867-5309'}
+    } />
+    <cfset template = "{{##contact}}({{name}}'s number is {{phone}}){{/contact}}">
+    <cfset expected = "(Jenny's number is 867-5309)" />
+  </cffunction>
+
+  <cffunction name="queryAsSection">
+    <cfset contacts = queryNew("name,phone")/>
+    <cfset queryAddRow(contacts)>
+    <cfset querySetCell(contacts, "name", "Jenny") />
+    <cfset querySetCell(contacts, "phone", "867-5309") />
+    <cfset queryAddRow(contacts)>
+    <cfset querySetCell(contacts, "name", "Tom") />
+    <cfset querySetCell(contacts, "phone", "555-1234") />
+    <cfset context = {contacts = contacts} />
+    <cfset template = "{{##contacts}}({{name}}'s number is {{phone}}){{/contacts}}">
+    <cfset expected = "(Jenny's number is 867-5309)(Tom's number is 555-1234)" />
+  </cffunction>
+
+  <cffunction name="missingQueryColumnIsSkipped">
+    <cfset contacts = queryNew("name")/>
+    <cfset queryAddRow(contacts)>
+    <cfset querySetCell(contacts, "name", "Jenny") />
+    <cfset context = {contacts = contacts} />
+    <cfset template = "{{##contacts}}({{name}}'s number is {{phone}}){{/contacts}}">
+    <cfset expected = "(Jenny's number is )" />
+  </cffunction>
+
+  <cffunction name="arrayAsSection">
+    <cfset context = {
+      contacts = [
+        { name = 'Jenny', phone = '867-5309'}
+        , { name = 'Tom', phone = '555-1234'}
+      ]
+    } />
+    <cfset template = "{{##contacts}}({{name}}'s number is {{phone}}){{/contacts}}">
+    <cfset expected = "(Jenny's number is 867-5309)(Tom's number is 555-1234)" />
+  </cffunction>
+
+  <cffunction name="missingStructKeyIsSkipped">
+    <cfset context = {
+      contacts = [
+        { name = 'Jenny', phone = '867-5309'}
+        , { name = 'Tom'}
+      ]
+    } />
+    <cfset template = "{{##contacts}}({{name}}'s number is {{^phone}}unlisted{{/phone}}{{phone}}){{/contacts}}">
+    <cfset expected = "(Jenny's number is 867-5309)(Tom's number is unlisted)" />
+  </cffunction>
+
+  <cffunction name="escape">
+    <cfset context = { thing = '<b>world</b>'} />
+    <cfset template = "Hello, {{thing}}!" />
+    <cfset expected = "Hello, &lt;b&gt;world&lt;/b&gt;!" />
+  </cffunction>
+
+  <cffunction name="dontEscape">
+    <cfset template = "Hello, {{{thing}}}!" />
+    <cfset context = { thing = '<b>world</b>'} />
+    <cfset expected = "Hello, <b>world</b>!" />
+  </cffunction>
+
+  <cffunction name="dontEscapeWithAmpersand">
+    <cfset context = { thing = '<b>world</b>'} />
+    <cfset template = "Hello, {{&thing}}!" />
+    <cfset expected = "Hello, <b>world</b>!" />
+  </cffunction>
+
+  <cffunction name="ignoreWhitespace">
+    <cfset context = { thing = 'world'} />
+    <cfset template = "Hello, {{   thing   }}!" />
+    <cfset expected = "Hello, world!" />
+  </cffunction>
+
+  <cffunction name="ignoreWhitespaceInSection">
+    <cfset context =  { set = true }  />
+    <cfset template = "Ready {{##  set  }}set {{/  set  }}go!" />
+    <cfset expected = "Ready set go!" />
+  </cffunction>
+
+  <cffunction name="callAFunction">
+    <cfset context = createObject("component", "Person")/>
+    <cfset context.firstname = "Chris" />
+    <cfset context.lastname = "Wanstrath" />
+    <cfset template = "Mustache was created by {{fullname}}." />
+    <cfset expected = "Mustache was created by Chris Wanstrath." />
+  </cffunction>
+
+  <cffunction name="filter">
+    <cfset context = createObject("component", "Filter")/>
+    <cfset template = "Hello, {{##bold}}world{{/bold}}." />
+    <cfset expected = "Hello, <b>world</b>." />
+  </cffunction>
+
+  <cffunction name="partial">
+	  <!--- using a subclass so that it will look for the partial in this directory --->
+		<cfset stache = createObject("component", "Winner").init()/>
+    <cfset context = { word = 'Goodnight', name = 'Gracie' } />
+    <cfset template = "<ul><li>Say {{word}}, {{name}}.</li><li>{{> gracie_allen}}</li></ul>" />
+    <cfset expected = "<ul><li>Say Goodnight, Gracie.</li><li>Goodnight</li></ul>" />
+  </cffunction>
+
+	<cffunction name="globalRegisteredPartial">
+		<!--- reinit, passing in the global partial --->
+		<cfscript>
+			var initPartials =
+			{
+				gracie_allen = fileRead(expandPath("/tests/gracie_allen.mustache"))
+			};
+		</cfscript>
+
+		<cfset stache = createObject("component", "mustache.Mustache").init(initPartials)/>
+		<cfset context = { word = 'Goodnight', name = 'Gracie' }/>
+		<cfset template = "<ul><li>Say {{word}}, {{name}}.</li><li>{{> gracie_allen}}</li></ul>"/>
+		<cfset expected = "<ul><li>Say Goodnight, Gracie.</li><li>Goodnight</li></ul>"/>
+	</cffunction>
+
+	<cffunction name="runtimeRegisteredPartial">
+
+		<cfscript>
+			partials =
+			{
+				gracie_allen = fileRead(expandPath("/tests/gracie_allen.mustache"))
+			};
+		</cfscript>
+
+		<cfset context = { word = 'Goodnight', name = 'Gracie' }/>
+		<cfset template = "<ul><li>Say {{word}}, {{name}}.</li><li>{{> gracie_allen}}</li></ul>"/>
+		<cfset expected = "<ul><li>Say Goodnight, Gracie.</li><li>Goodnight</li></ul>"/>
+
+	</cffunction>
+
+	<cffunction name="invertedSectionHiddenIfStructureNotEmpty">
+		<cfset context =  {set = {something='whatever'}}  />
+		<cfset template = "{{##set}}This sentence should be showing.{{/set}}{{^set}}This sentence should not.{{/set}}" />
+		<cfset expected = "This sentence should be showing." />
+	</cffunction>
+	
+	<cffunction name="invertedSectionHiddenIfQueryNotEmpty">
+	    <cfset contacts = queryNew("name,phone")/>
+	    <cfset queryAddRow(contacts)>
+	    <cfset querySetCell(contacts, "name", "Jenny") />
+	    <cfset querySetCell(contacts, "phone", "867-5309") />
+	    <cfset context = {set = contacts} />
+		<cfset template = "{{##set}}This sentence should be showing.{{/set}}{{^set}}This sentence should not.{{/set}}" />
+		<cfset expected = "This sentence should be showing." />
+	</cffunction>
+	
+	<cffunction name="invertedSectionHiddenIfArrayNotEmpty">
+	    <cfset context =  {set = [1]}  />
+		<cfset template = "{{##set}}This sentence should be showing.{{/set}}{{^set}}This sentence should not.{{/set}}" />
+		<cfset expected = "This sentence should be showing." />
+	</cffunction>
+
+</cfcomponent>

--- a/tests/Tests.cfc
+++ b/tests/Tests.cfc
@@ -1,5 +1,6 @@
 <cfcomponent output="false" extends="mxunit.framework.TestSuite">
   <cfset addAll("tests.RenderTest")>
   <cfset addAll("tests.WinnerTest") />
-<cfset addAll("tests.one.two.three.WinnerTest") />
+  <cfset addAll("tests.one.two.three.WinnerTest") />
+  <cfset addAll("tests.CustomTagTest") />
 </cfcomponent>


### PR DESCRIPTION
I have created a custom tag version so you can render templates like:

``` cfml
<cfset context = {
    name = "Patrick",
    value = 1000,
    in_ca = true,
    taxed_value = 600
} />

<cfimport taglib="/path/to/mustache/dir" prefix="stache" />
<stache:mustache context="#context#">
<cfoutput>
Hello {{name}}
You have just won ${{value}}!
{{##in_ca}}
Well, ${{taxed_value}}, after taxes.
{{/in_ca}}
</cfoutput>
</stache:mustache>
```

I updated the readme and provided a unit test.
