### PR TITLE
Remove regex caching: memory leak & Lambda evaluation refactor.

### DIFF
--- a/tests/RenderTest.cfc
+++ b/tests/RenderTest.cfc
@@ -13,9 +13,6 @@
 		<cfabort />
 --->
 		<cfset assertEquals(expected, stache.render(template, context, partials))/>
-
-		<!--- since we now have regex result caching, run it again, make sure nothing changes --->
-		<cfset assertEquals(expected, stache.render(template, context, partials))/>
 	</cffunction>
 
   <cffunction name="basic">


### PR DESCRIPTION
This is actually 2 things:

1) Remove the regex caching. In our tests it was bringing down our servers with a memory leak. Doesn't seem to be giving us much major performance improvement anyway.

2) Move the lambda call into it's own method, so that it can be overwritten when extending Mustache.
