### PR TITLE
Added description comment and moved private variables into "Mustache" namespace

### DIFF
--- a/mustache/MustacheFormatter.cfc
+++ b/mustache/MustacheFormatter.cfc
@@ -23,7 +23,7 @@
 --->
 
 	<!---// captures arguments to be passed to formatter functions //--->
-	<cfset variables.ArgumentsRegEx = createObject("java","java.util.regex.Pattern").compile("[^\s,]*(?<!\\)\(.*?(?<!\\)\)|(?<!\\)\[.*?(?<!\\)\]|(?<!\\)\{.*?(?<!\\)\}|(?<!\\)('|"").*?(?<!\\)\1|(?:(?!,)\S)+", 40) />
+	<cfset variables.Mustache.ArgumentsRegEx = createObject("java","java.util.regex.Pattern").compile("[^\s,]*(?<!\\)\(.*?(?<!\\)\)|(?<!\\)\[.*?(?<!\\)\]|(?<!\\)\{.*?(?<!\\)\}|(?<!\\)('|"").*?(?<!\\)\1|(?:(?!,)\S)+", 40) />
 
 	<!---// overwrite the default methods //--->
   <cffunction name="onRenderTag" access="private" output="false">
@@ -51,7 +51,7 @@
 					<!---// get the arguments from the function name //--->
 					<cfset local.args = replace(local.fn, local.fnName & "(", "") />
 					<!---// gets the arguments from the string //--->
-					<cfset local.args = regexMatch(left(local.args, len(local.args)-1), variables.ArgumentsRegEx) />
+					<cfset local.args = regexMatch(left(local.args, len(local.args)-1), variables.Mustache.ArgumentsRegEx) />
 				<cfelse>
 					<cfset local.args = [] />
 				</cfif>


### PR DESCRIPTION
Just a few minor changes. I thought it was worth having a comment at the top describing the component, but more importantly having a link to the original source code (I hate when people implement source code into a project, but you have no idea where the code originally came from.)

I also put all the private variables into a "Mustache" namespace--which I thought might help avoid issues when extending the component.

Here's a sumarry:
- Moved private variables into a Mustache name space to avoid variable collisions when extending Mustache.cfc
- Added heading comment to reference where the original source can be found and to list key benefits of this implementation
- Added missing XHTML-style closing tags where missing
- Changes "result" to "results" to be consisted across all functions
