### PR TITLE
Added "options" struct which can be used to alter behavior when overriding methods

### DIFF
--- a/tests/MustacheOverride.cfc
+++ b/tests/MustacheOverride.cfc
@@ -3,6 +3,12 @@
 	<cffunction name="textEncode" access="private" output="false"
 		hint="Encodes a plain text string (can be overridden)">
 		<cfargument name="input"/>
+		<cfargument name="options"/>
+
+		<!---// check the options //--->
+		<cfif structKeyExists(arguments.options, "useDefault") and arguments.options.useDefault>
+			<cfreturn super.textEncode(argumentCollection=arguments) />
+		</cfif>
 
 		<cfreturn "`" & arguments.input & "`" />
 	</cffunction>
@@ -10,6 +16,12 @@
 	<cffunction name="htmlEncode" access="private" output="false"
 		hint="Encodes a string into HTML (can be overridden)">
 		<cfargument name="input"/>
+		<cfargument name="options"/>
+
+		<!---// check the options //--->
+		<cfif structKeyExists(arguments.options, "useDefault") and arguments.options.useDefault>
+			<cfreturn super.htmlEncode(argumentCollection=arguments) />
+		</cfif>
 
 		<cfreturn "|" & arguments.input & "|" />
 	</cffunction>

--- a/tests/MustacheOverrideTest.cfc
+++ b/tests/MustacheOverrideTest.cfc
@@ -2,12 +2,13 @@
 
 	<cffunction name="setup">
 		<cfset partials = {} />
+		<cfset options = {} />
 		<cfset stache = createObject("component", "MustacheOverride").init() />
 	</cffunction>
 
 	<cffunction name="tearDown">
 		<!---// make sure tests are case sensitive //--->
-		<cfset assertEqualsCase(expected, stache.render(template, context, partials))/>
+		<cfset assertEqualsCase(expected, stache.render(template, context, partials, options))/>
 		<!---// reset variables //--->
 		<cfset partials = {} />
 		<cfset context = {} />
@@ -23,6 +24,20 @@
     <cfset context = { thing = 'World'} />
     <cfset template = "Hello, {{thing}}!" />
     <cfset expected = "Hello, |World|!" />
+  </cffunction>
+
+  <cffunction name="textEncode_options_useDefault">
+		<cfset options = {useDefault=true} />
+    <cfset context = { thing = '<b>World</b>'} />
+    <cfset template = "Hello, {{{thing}}}!" />
+    <cfset expected = "Hello, #context.thing#!" />
+  </cffunction>
+
+  <cffunction name="htmlEncode_options_useDefault">
+		<cfset options = {useDefault=true} />
+    <cfset context = { thing = '<b>World</b>'} />
+    <cfset template = "Hello, {{thing}}!" />
+    <cfset expected = "Hello, #htmlEditFormat(context.thing)#!" />
   </cffunction>
 
 </cfcomponent>


### PR DESCRIPTION
Added "options" argument to render which can be used to pass in options for when you need to overwrite a default behavior. This struct is passed to all major methods as a way to supply a thread-safe way to change behavior for a specific instance of a rendering
