### PR TITLE
openbluedragon does not work due to a global function called render

### DIFF
--- a/mustache/Mustache.cfc
+++ b/mustache/Mustache.cfc
@@ -334,9 +334,9 @@
 		<cfargument name="options"/>
 
 		<cfif structKeyExists(arguments.partials, arguments.name)>
-			<cfreturn render(arguments.partials[arguments.name], arguments.context, arguments.partials, arguments.options)/>
+			<cfreturn this.render(arguments.partials[arguments.name], arguments.context, arguments.partials, arguments.options)/>
 		<cfelse>
-			<cfreturn render(readMustacheFile(arguments.name), arguments.context, arguments.partials, arguments.options)/>
+			<cfreturn this.render(readMustacheFile(arguments.name), arguments.context, arguments.partials, arguments.options)/>
 		</cfif>
 
 	</cffunction>


### PR DESCRIPTION
function render collides with a global function render in openbd engine. 
The this scope has to be applied in the cfc.
